### PR TITLE
WaveRNN: add as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "WaveRNN"]
+	path = WaveRNN
+	url = https://github.com/marzus555/WaveRNN.git


### PR DESCRIPTION
Since the voice synthesizing process makes use
of the waveRNN vocoder too, it might be simpler to
add the corresponding vocoder repository as a submodule
to the main repository.

This way, when running inference, the two repositories
no longer have to be manually downloaded and merged. Instead,
the latest version of the vocoder repository can be obtained
by running the following command inside the TTS repo:
`git submodule update --init --recursive`.

Signed-off-by: Gabriel Bercaru <gabriel.bercaru10@gmail.com>